### PR TITLE
[FIX] port forwarding: different port for each peer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2024"
 tokio = { version = "1.45", features = ["full"] }
 
 actix = "0.13"
-actix-web = "4"
+actix-web = "4.11"
 actix-web-actors = "4"
 actix-cors = "0.7.1"
 
@@ -23,9 +23,9 @@ dotenv = "0.15.0"
 
 diesel = { version = "2.2.10", features = ["sqlite", "chrono", "r2d2"] }
 chrono = { version = "0.4", features = ["serde"] }
-onetun = "0.3.10"
-env_logger = "0.7.1"
-tokio-util = "0.7.14"
+onetun = { path = "../onetun" }
+env_logger = "0.11.8"
+reqwest = "0.12.15"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/src/client/configuration.rs
+++ b/src/client/configuration.rs
@@ -48,6 +48,8 @@ pub async fn add_peer(
         &data.endpoint,
         &data.peer_ip,
         &data.interface_ip,
+        Some("8081"),
+        Some("4567"),
     );
 
     peer_configs.tunnels
@@ -55,6 +57,8 @@ pub async fn add_peer(
         .await
         .insert(data.peer_public_key.clone(), start_tunnel(Some(config)).await.unwrap());
 
+    println!("Peer added: {:?}", data.peer_public_key);
+    
     HttpResponse::Ok().body("WireGuard configured")
 }
 
@@ -73,4 +77,3 @@ pub async fn update_peer_endpoint(
         HttpResponse::NotFound().body("Endpoint not found")
     }
 }
-

--- a/src/client/hub.rs
+++ b/src/client/hub.rs
@@ -1,5 +1,6 @@
 use actix::{Actor, Addr, Context, Handler, Message};
 use std::collections::HashMap;
+use crate::client::messenger::MessagePayload;
 use crate::client::ws_session::{
     ServerMessage,
     WsSession,
@@ -16,13 +17,6 @@ pub struct Connect {
 #[rtype(result = "()")]
 pub struct Disconnect {
     pub peer_key: String,
-}
-
-#[derive(Message)]
-#[rtype(result = "()")]
-pub struct ForwardMessage {
-    pub to: String,
-    pub payload: String,
 }
 
 pub struct Hub {
@@ -53,11 +47,11 @@ impl Handler<Disconnect> for Hub {
     }
 }
 
-impl Handler<ForwardMessage> for Hub {
+impl Handler<MessagePayload> for Hub {
     type Result = ();
-    fn handle(&mut self, msg: ForwardMessage, _: &mut Context<Self>) {
+    fn handle(&mut self, msg: MessagePayload, _: &mut Context<Self>) {
         if let Some(addr) = self.sessions.get(&msg.to) {
-            addr.do_send(ServerMessage(msg.payload));
+            addr.do_send(ServerMessage(msg.message));
         }
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -3,6 +3,7 @@ pub mod ws_session;
 mod configuration;
 mod messenger;
 
+use std::env;
 use actix_cors::Cors;
 use actix_web::{web, App, HttpServer, http};
 use actix::Actor;
@@ -14,12 +15,12 @@ use crate::client::hub::Hub;
 pub async fn client_api(pool: DbPool) -> std::io::Result<()> {
     let hub_addr: Addr<Hub> = Hub::new().start();
     let peer_configs = configuration::PeerConfigs::new();
+    let public_key = env::var("iface_public_key").expect("Missing iface_public_key in .env");
 
     HttpServer::new(move || {
         let cors = Cors::default()
-        // En prod, restreignez plutôt à votre domaine front, p. ex. "https://votre-site.com"
             .allowed_origin("http://localhost:5173")  
-            .allowed_methods(vec!["GET", "POST", "PUT", "DELETE", "OPTIONS"])
+            .allowed_methods(vec!["GET", "POST"])
             .allowed_headers(vec![http::header::AUTHORIZATION, http::header::CONTENT_TYPE])
             .max_age(3600);
 
@@ -29,10 +30,12 @@ pub async fn client_api(pool: DbPool) -> std::io::Result<()> {
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(hub_addr.clone()))
             .app_data(web::Data::new(peer_configs.clone()))
+            .app_data(web::Data::new(public_key.clone()))
             .route("/", web::get().to(ws_session::ws_index))
             .route("/add_peer", web::post().to(configuration::add_peer))
             .route("/update_endpoint", web::post().to(configuration::update_peer_endpoint))
             .route("/get_peers", web::get().to(messenger::get_all_peers))
+            .route("/receive", web::post().to(messenger::receive))
     })
     .bind("0.0.0.0:49369")?
     .run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pool = init();
 
     local.run_until(async {
-        onetun::start_tunnels(Config::from(wg::get_base_config()), bus.clone()).await.unwrap(); // tunnel to tailscale
-        client::client_api(pool).await.unwrap();
+        tokio::join!(
+            async {
+                client::client_api(pool).await.unwrap();
+            },
+            async {
+                onetun::start_tunnels(Config::from(wg::get_base_config()), bus).await.unwrap();
+            }
+        );
     }).await;
 
     Ok(())


### PR DESCRIPTION
we were always assigning the same port (8080) to new peers, leading to conflicts when more than one peer.